### PR TITLE
Ensure next token exists

### DIFF
--- a/src/extract/parser.ts
+++ b/src/extract/parser.ts
@@ -43,7 +43,7 @@ export function parseFunctionCall(mapping: KeywordMapping, tokens: Token[]): Msg
     const stringArgs: string[] = [];
 
     // parse strings arguments
-    while (true) {
+    while (t) {
       if (t.kind !== TokenKind.String) {
         break;
       }


### PR DESCRIPTION
Edge cases where there's no token after the comma, particular in Prettier formatted files where long strings are given their own line and then a trailing comma because they are now in a multi-line function call.

Example:

    <p>
        {{
            __(
                'Lorem ipsum dolor sit amet consectetur. Quis nec cursus pharetra nisl. Praesent at velit urna nec dictum tortor non. Neque laoreet eu tellus erat porttitor egestas.',
            )
        }}
    </p>

This causes the extract to fail durning parseFunctionCall's nested while loop due to it blindly advancing to the next token without checking if it exists. An alternative code solution would be to test `t` at the very end, but making it the condition for the while loop should suffice.